### PR TITLE
Remove unnecessary top-level call

### DIFF
--- a/js2-highlight-vars.el
+++ b/js2-highlight-vars.el
@@ -109,8 +109,7 @@
                  (overlay-put ovl 'evaporate t)
                  (overlay-put ovl 'js2-highlight-vars t)))
              t)))
-        (setq js2--highlight-vars-tokens tokens)
-        (top-level)))))
+        (setq js2--highlight-vars-tokens tokens)))))
 
 (defun js2-highlight-vars-next ()
   (interactive)

--- a/js2-highlight-vars.el
+++ b/js2-highlight-vars.el
@@ -4,7 +4,7 @@
 ;; Author:  Mihai Bazon <mihai.bazon@gmail.com>
 ;; Version: 0.1.0
 ;; URL: http://mihai.bazon.net/projects/editing-javascript-with-emacs-js2-mode/js2-highlight-vars-mode
-;; Package-Requires: ((js2-mode "20150908"))
+;; Package-Requires: ((emacs "24.4") (js2-mode "20150908"))
 
 ;;; Commentary:
 ;;


### PR DESCRIPTION
This was a workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=4081, which results in an annoying "back to top level" message and messes up recursive editing. Since the bug is fixed now, the workaround can be removed